### PR TITLE
few modification on the local authority text

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -14,18 +14,6 @@ app_ui <- function(request) {
     br(),
     fluidPage(
       mod_01_intro_ui("01_intro_1"),
-      # scrollytell::scrolly_container(
-      #   outputId = "scrolly_1",
-      #   scrollytell::scrolly_graph(),
-      #   scrollytell::scrolly_sections(
-      #     scrollytell::scrolly_section(
-      #       id = "01_intro",
-      #       mod_01_intro_ui("01_intro_1"),
-      #
-      #     )
-      #   )
-      # ),
-
       scrollytell::scrolly_container(
         outputId = "scrolly_2",
         scrollytell::scrolly_graph(),
@@ -85,7 +73,7 @@ app_ui <- function(request) {
         )
       ),
 
-      # Take up - map section (only for region level)
+      # Regional level take-up map
       scrollytell::scrolly_container(
         outputId = "scrolly_6",
         scrollytell::scrolly_graph(),
@@ -100,8 +88,8 @@ app_ui <- function(request) {
         )
       ),
 
-      # Take-up LA - scatterplot text on the left
-      # scatterplot chart and zoomed LA map on the right
+      # Take-up LA - scatterplot text on the top
+      # Scatterplot chart and zoomed LA map on the bottom
 
       scrollytell::scrolly_container(
         outputId = "scrolly_7",
@@ -125,13 +113,10 @@ app_ui <- function(request) {
               )
             )
           ),
-          br(),
-          br(),
-          br(),
           scrollytell::scrolly_section(
-            # here, i will use pre-defined text to show alongside with scatterpot change and map change.
+            # Text changes with more flexible contents
             id = "07_take_up_scatter_text",
-            mod_07_take_up_scatter_text_ui("07_take_up_scatter_text_1") # based on the selection of region, it will change dynamically
+            mod_07_take_up_scatter_text_ui("07_take_up_scatter_text_1")
           )
         )
       ),

--- a/R/mod_07_take_up_scatter_graph.R
+++ b/R/mod_07_take_up_scatter_graph.R
@@ -250,7 +250,9 @@ mod_07_take_up_scatter_graph_server <- function(input, output, session, region_n
               labels = list(format = "{value:.0f}%")
             ),
             series = list(list(color = "#425563"))
-          )
+          ),
+          height = 200,
+          width = 250
         )
       )
   })

--- a/R/mod_07_take_up_scatter_text.R
+++ b/R/mod_07_take_up_scatter_text.R
@@ -94,8 +94,8 @@ mod_07_take_up_scatter_text_server <- function(input, output, session, region_na
         "<b>", highest_take_up_la()[2], "</b>.",
         "<b>", lowest_take_up_la()[1], " </b> has the lowest take-up in the", region_sel(),
         ", with an IMD rank of", "<b>", lowest_take_up_la()[2], " </b> out of the 314 local authorities in England.",
-        "Take-up is somewhat", "<b> lower, relative to deprivation </b>", "in five local authorities in the", "<b> North East </b>",
-        "<b> (Knowsley, Hyndburn, Halton, St Helens and Barrow in Furness and North East Lincolnshire Council."
+        "Take-up is somewhat", "<b> lower, relative to deprivation </b>", "in four local authorities in the", "<b> North West </b>",
+        "<b> (Knowsley, Hyndburn, Halton, St Helens and Barrow in Furness.)"
       ))
     } else if (region_sel() == "North East") {
       shiny::HTML(paste(

--- a/R/mod_input_region.R
+++ b/R/mod_input_region.R
@@ -11,7 +11,7 @@ mod_input_region_ui <- function(id,
                                 label = "Region:",
                                 min = "East Midlands",
                                 max = "Yorkshire and The Humber",
-                                selected = "North East",
+                                selected = "North West",
                                 width = "40%") {
   ns <- NS(id)
 


### PR DESCRIPTION
Take-up: instead of zooming ability (failed to get the x-y coordinate), so I've tried with different approach.

Region take-up change style similar to student region map

Local authority and scatterplot show together in scrolly_graph section. However, I had to add input dropdown menu for year selection as I couldn't use sequence (list) for tooltip_chart part. 